### PR TITLE
新增商店後台layout (Feat#issue 54)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'bootsnap', require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
-  gem "dotenv-rails", "~> 2.8"
+  gem 'dotenv-rails', '~> 2.8'
 end
 
 group :development do
@@ -91,3 +91,5 @@ gem 'pg', '~> 1.5'
 gem 'devise', '~> 4.9'
 
 gem 'rubocop', '~> 1.59', require: false
+
+gem 'pundit', '~> 2.3'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from ActiveRecord::RecordNotSaved, with: :not_saved
+  rescue_from Pundit::NotAuthorizedError, with: :not_authorized
   helper_method :current_user_shop
   layout :set_layout # 設置判斷登入的使用者layout頁面
 
@@ -27,6 +29,24 @@ class ApplicationController < ActionController::Base
 
   def current_user_shop
     current_user.shop
+    Shop.where(user_id: current_user.id)
+  end
+
+  def authenticate_user!
+    return if user_signed_in?
+
+    respond_to do |format|
+      format.html do
+        redirect_to sign_in_users_path, alert: '請先登入帳號'
+      end
+
+      format.json do
+        render json: {
+          message: '請先登入帳號',
+          url: sign_in_users_path
+        }, status: 401
+      end
+    end
   end
 
   def set_layout
@@ -35,5 +55,9 @@ class ApplicationController < ActionController::Base
     else
       'application'
     end
+  end
+
+  def not_authorized
+    redirect_to root_path, alert: '權限不足'
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from ActiveRecord::RecordNotSaved, with: :not_saved
   helper_method :current_user_shop
+  layout :set_layout # 設置判斷登入的使用者layout頁面
 
   def not_found
     render file: Rails.public_path.join('404.html'),
@@ -26,5 +27,13 @@ class ApplicationController < ActionController::Base
 
   def current_user_shop
     current_user.shop
+  end
+
+  def set_layout
+    if current_user&.vendor?
+      'vendor'
+    else
+      'application'
+    end
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -9,6 +9,7 @@ class ProductsController < ApplicationController
     authorize Product
     @q = Product.ransack(params[:q])
     @products = @q.result
+                  .where(onsale: true)
                   .order(order_by)
                   .page(params[:page])
                   .per(8)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,8 +2,11 @@
 
 class ProductsController < ApplicationController
   before_action :find_product, only: %i[show edit update destroy]
+  before_action :authenticate_user!, except: %i[index show]
+  before_action :find_owned_product, only: %i[edit update destroy]
 
   def index
+    authorize Product
     @q = Product.ransack(params[:q])
     @products = @q.result
                   .order(order_by)
@@ -11,51 +14,73 @@ class ProductsController < ApplicationController
                   .per(8)
   end
 
-  def show; end
+  def show
+    authorize Product
+  end
+
+  def my
+    authorize Product
+    @products = current_user_shop.first.products
+                                 .unscope(where: :onsale)
+                                 .page(params[:page])
+                                 .per(8)
+  end
 
   def new
+    authorize Product
     @product = Product.new
   end
 
   def create
-    @product = Product.new(product_params)
+    authorize Product
+    @product = current_user.shop.products.new(product_params)
+
     if @product.save
-      redirect_to products_path, notice: '新增商品成功'
+      redirect_to my_products_path, notice: '商品創建成功'
     else
       render :new
     end
   end
 
-  def edit; end
+  def edit
+    authorize @product
+  end
 
   def update
+    authorize @product
     if @product.update(product_params)
-      redirect_to product_path(@product), notice: '更新成功'
+      redirect_to my_products_path, notice: '更新成功'
     else
       render :edit
     end
   end
 
   def destroy
-    return unless @product.destroy
+    authorize @product
 
-    redirect_to root_path, notice: '商品已刪除'
+    @product.destroy
+    redirect_to root_path, alert: '商品已刪除'
   end
 
   def search
-    data = Product.ransack(title_cont: params[:q])
-    @products = data.result
+    authorize Product
+    @products = Product.ransack(title_cont: params[:q]).result
   end
 
   private
 
   def product_params
     params.require(:product)
-          .permit(:title, :cover, :price, :description, :service_min, :onsale)
+          .permit(:title, :cover, :price, :description, :service_min, :onsale, :publish_date, :shop_id)
   end
 
   def find_product
     @product = Product.find(params[:id])
+  end
+
+  def find_owned_product
+    @product = Product.unscope(where: :onsale)
+                      .find(params[:id])
   end
 
   def order_by

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -13,19 +13,15 @@ class ShopsController < ApplicationController
   end
 
   def new
-    if current_user.shop.present?
-      redirect_to new_product_path,
-      alert: t(:already_own_store, scope: %i[views shop message])
-    else
-      @shop = Shop.new
-    end
+    authorize Shop, :new?
+    @shop = Shop.new
   end
 
   def create
+    authorize Shop, :create?
     @shop = current_user.build_shop(shop_params)
     if @shop.save
-      redirect_to shop_path(@shop), 
-      notice: t(:list_your_services_products, scope: %i[views shop message])
+      redirect_to shop_path(@shop), notice: t(:list_your_services_products, scope: %i[views shop message])
     else
       render :new
     end
@@ -33,8 +29,7 @@ class ShopsController < ApplicationController
 
   def edit; end
 
-  def show
-  end
+  def show; end
 
   def update
     if @shop.update(shop_params)
@@ -44,8 +39,7 @@ class ShopsController < ApplicationController
     end
   end
 
-  def destroy
-  end
+  def destroy; end
 
   private
 
@@ -78,9 +72,8 @@ class ShopsController < ApplicationController
   end
 
   def check_ownership
-    if current_user == @shop
-      redirect_to root_path, alert: t(:wrong_way, scope: %i[views shop message])
-    end
+    return unless current_user == @shop
+
+    redirect_to root_path, alert: t(:wrong_way, scope: %i[views shop message])
   end
-  
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -34,13 +34,13 @@ class Shop < ApplicationRecord
     self.user == user
   end
 
-  #商店排序用，允許被搜尋到的東西
-  def self.ransackable_attributes(auth_object = nil)
-    ["city", "description", "district", "status", "street", "title", "updated_at", "open"]
-  end
-  #這行刪掉會壞掉，所以保留
-  def self.ransackable_associations(auth_object = nil)
-    ["products"]
+  # 商店排序用，允許被搜尋到的東西
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[city description district status street title updated_at open]
   end
 
+  # 這行刪掉會壞掉，所以保留
+  def self.ransackable_associations(_auth_object = nil)
+    ['products']
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  enum role: %i[general vendor]
+  enum role: %i[general vendor admin]
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, confirmation: true
   has_one :shop
@@ -14,5 +14,9 @@ class User < ApplicationRecord
 
   def liked?(shop)
     liked_shop_ids.include?(shop.id)
+  end
+
+  def own?(product)
+    shop&.products&.unscope(where: :onsale)&.include?(product)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  enum role: %i[general vendor]
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, confirmation: true
   has_one :shop

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -1,0 +1,58 @@
+class ProductPolicy < ApplicationPolicy
+  attr_reader :user, :product
+
+  def initialize(user, product)
+    @user = user
+    @product = product
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def my?
+    (user.vendor? && user.shop.present?) || user.admin?
+  end
+
+  def new?
+    vendor_with_shop? || user.admin?
+  end
+
+  def create?
+    vendor_with_shop? || user.admin?
+  end
+
+  def edit?
+    vendor_with_shop? || (user.admin? && user_can_manage_product_in_shop?)
+  end
+
+  def update?
+    vendor_with_shop? || (user.present? && user.admin? && user_can_manage_product_in_shop?)
+  end
+
+  def destroy?
+    vendor_with_shop? || (user.admin? && user_can_manage_product_in_shop?)
+  end
+
+  def search?
+    true
+  end
+
+  private
+
+  def vendor_with_shop?
+    user.present? && user.vendor? && user.shop.present?
+  end
+
+  def user_can_manage_product_in_shop?
+    user.admin? && product.shop_id == user_assigned_shop_id
+  end
+
+  def user_assigned_shop_id
+    user.assigned_shop_id
+  end
+end

--- a/app/policies/shop_policy.rb
+++ b/app/policies/shop_policy.rb
@@ -1,0 +1,18 @@
+class ShopPolicy < ApplicationPolicy
+  attr_reader :user, :shop
+
+  def initialize(user, shop)
+    @user = user
+    @shop = shop
+  end
+
+  def new?
+    user.vendor? && user.shop.nil?
+    # 只有 User 的 role 為 'vendor' 且尚未擁有店鋪時才能夠創建店鋪
+  end
+
+  def create?
+    user.vendor? && user.shop.nil?
+    # 只有 User 的 role 為 'vendor' 且尚未擁有店鋪時才能夠創建店鋪
+  end
+end

--- a/app/views/layouts/vendor.html.erb
+++ b/app/views/layouts/vendor.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html data-theme="autumn">
+  <head>
+    <title>RestTime</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
+    
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  </head>
+
+  <body>
+    <%= render "shared/navbar" %>
+    <%= render "shared/flash" if flash.any? %>
+    <main class="container p-4 mx-auto">
+        <h1>使用者後台</h1>
+      <%= yield %>
+    </main>
+    <%= render "shared/footer" %>
+  </body>
+</html>

--- a/app/views/products/_item.html.erb
+++ b/app/views/products/_item.html.erb
@@ -1,0 +1,12 @@
+<%= tag.li data: { id: product.id },
+           class: class_names('p-2 bg-white border rounded shadow border-slate-300', grayscale: !product.onsale, 'grayscale-0': product.onsale) do %>
+  <div>
+    <%= link_to edit_product_path(product) do %>
+      <figure>
+        <%= product_cover(product) %>
+      </figure>
+    <% end %>
+    <h2 class="font-bold"><%= link_to product.title, product_path(product) %></h2>
+    <span>NT$ <%= product.price %></span>
+  </div>
+<% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,6 +1,11 @@
 <p class="fs-5 p-1">商品列表</p>
+<% if user_signed_in? %>
 
-<%= link_to  "新增商品", new_product_path, class: 'btn'%>
+  <%= link_to  "新增商品", new_product_path, class: 'btn'%>
+  <%= link_to '我的商品', my_products_path, class: 'btn btn-primary mb-4' %>
+
+<% end %>
+
 
 <div class="grid grid-cols-1 gap-3">
 <%= search_form_for @q do |f| %>

--- a/app/views/products/my.html.erb
+++ b/app/views/products/my.html.erb
@@ -1,0 +1,12 @@
+<h1 class="mb-4 text-2xl">已上架商品</h1>
+
+<%= link_to t('products.create'), new_product_path, class: 'btn btn-primary mb-4' %>
+
+<ul data-controller="drag"
+    class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
+  <%= render partial: 'item', collection: @products, as: :product %>
+</ul>
+
+<footer>
+  <%= paginate @products %>
+</footer>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,10 +1,11 @@
 
-<h1><%= @product.title %></h1>
+<% if policy(@product).update? %>
   <%= link_to "編輯商品", edit_product_path, class: 'ink-btn' %>
   <%= link_to '刪除商品', product_path(@product), class: 'ink-btn ink-btn-danger', data: {
    turbo_method: 'delete',
    turbo_confirm: '確認刪除？'
  } %>
+<% end %>
 <%= image_tag @product.cover.variant(:thumb) if @product.cover.attached? %>
 
 <h3>售價:<%= @product.price %>元</h3>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -23,15 +23,6 @@
         <li><%= link_to '登入', new_user_session_path %></li>
       <% end %>
 
-      <%#是否轉為店家後台判斷%>
-      <% if current_user %>
-        <%= current_user.role %>
-          <%= link_to "logout", destroy_user_session_path, method: :delete, data: { turbo_method: :delete} %>
-      <% else %>
-          <%= link_to "log_in", new_user_session_path %>
-      <% end %>
-
-
       <div>
         <form action="<%= search_path %>" data-turbo="false">
           <input type="search" name="q" class="text-black input input-bordered">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -23,6 +23,15 @@
         <li><%= link_to '登入', new_user_session_path %></li>
       <% end %>
 
+      <%#是否轉為店家後台判斷%>
+      <% if current_user %>
+        <%= current_user.role %>
+          <%= link_to "logout", destroy_user_session_path, method: :delete, data: { turbo_method: :delete} %>
+      <% else %>
+          <%= link_to "log_in", new_user_session_path %>
+      <% end %>
+
+
       <div>
         <form action="<%= search_path %>" data-turbo="false">
           <input type="search" name="q" class="text-black input input-bordered">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,12 @@ Rails.application.routes.draw do
   scope '(:lang)', locale: /en|tw/ do
     root 'products#index'
 
-    resources :products
+    resources :products do
+      collection do
+        get :my
+      end
+    end
+
     resources :shops
     resource :service_times, only: %i[edit update]
 

--- a/db/migrate/20231223170829_add_role_to_users.rb
+++ b/db/migrate/20231223170829_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :role, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_22_140539) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_23_170829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -129,6 +129,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_22_140539) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.integer "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -142,6 +143,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_22_140539) do
   add_foreign_key "products", "shops"
   add_foreign_key "ratings", "products"
   add_foreign_key "ratings", "users"
-  add_foreign_key "shops", "users"
   add_foreign_key "service_times", "shops"
+  add_foreign_key "shops", "users"
 end

--- a/test/policies/product_policy_test.rb
+++ b/test/policies/product_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ProductPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/shop_policy_test.rb
+++ b/test/policies/shop_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ShopPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
- 因為需要 新增店家i18n,地圖 #55 [feat-issue-09](https://github.com/astrocamp/15th-RestTime/tree/feat-issue-09)的修正更新，所以以此rebase建立新分支
- 新增User的column:role， 在User的model新增enum role: %i[general vendor]
- 新增判斷current_user是否跳轉頁面，放在_navbar_html.erb
- 在application_controller新增 layout :set_layout # 設置判斷登入的使用者layout頁面

User.role設定成功
<img width="190" alt="截圖 2023-12-24 凌晨1 12 36" src="https://github.com/astrocamp/15th-RestTime/assets/147526390/00409c6c-d05e-43d3-84b0-cacd46219190">
測試登入後台成功，並成功顯示User的店家
<img width="1428" alt="截圖 2023-12-24 凌晨1 12 59" src="https://github.com/astrocamp/15th-RestTime/assets/147526390/917e4968-8094-47d7-921b-306d2d073053">


