### PR TITLE
修改後台連結可隱藏，Feat issue 100

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,5 +19,8 @@ application.register("qrcode", QrcodeController);
 import ProductsController from "./products_controller";
 application.register("products", ProductsController);
 
-import TimepickerController from "./timepicker_controller";
-application.register("timepicker", TimepickerController);
+import SidebarController from "./sidebar_controller"
+application.register("sidebar", SidebarController)
+
+import TimepickerController from "./timepicker_controller"
+application.register("timepicker", TimepickerController)

--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -2,12 +2,11 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="sidebar"
 export default class extends Controller {
-  static targets = [ "toggleable" ]   
-  
-  connect() {
-    console.log("成功");
-  }
-  toggle(){
-    console.log(this.toggleableTarget)
+  static targets = ["menu"];
+  isMenuVisible = false;
+
+  toggle() {
+    this.isMenuVisible = !this.isMenuVisible;
+    this.menuTarget.classList.toggle("hidden", !this.isMenuVisible);
   }
 }

--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -3,10 +3,8 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="sidebar"
 export default class extends Controller {
   static targets = ["menu"];
-  isMenuVisible = false;
 
   toggle() {
-    this.isMenuVisible = !this.isMenuVisible;
-    this.menuTarget.classList.toggle("hidden", !this.isMenuVisible);
+    this.menuTarget.classList.toggle("hidden", this.isMenuVisible);
   }
 }

--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="sidebar"
+export default class extends Controller {
+  static targets = [ "toggleable" ]   
+  
+  connect() {
+    console.log("成功");
+  }
+  toggle(){
+    console.log(this.toggleableTarget)
+  }
+}

--- a/app/views/layouts/vendor.html.erb
+++ b/app/views/layouts/vendor.html.erb
@@ -11,12 +11,11 @@
     
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <div class="mb-24">
-    <%= render "vendor/navbar" %>
+      <%= render "vendor/navbar" %>
     </div>
     </div>
     <%= render "shared/flash" if flash.any? %>
     </div>
-
   </head>
 
   <body>

--- a/app/views/layouts/vendor.html.erb
+++ b/app/views/layouts/vendor.html.erb
@@ -10,7 +10,10 @@
     <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
     
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <div class="mb-24">
     <%= render "vendor/navbar" %>
+    </div>
+    </div>
     <%= render "shared/flash" if flash.any? %>
     </div>
 

--- a/app/views/layouts/vendor.html.erb
+++ b/app/views/layouts/vendor.html.erb
@@ -10,17 +10,14 @@
     <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
     
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    <%= render "shared/navbar" %>
-    <div class="mt-16">
+    <%= render "vendor/navbar" %>
     <%= render "shared/flash" if flash.any? %>
     </div>
 
   </head>
 
   <body>
-        
-    <main class="mt-24 p-5">
-      <%= render "vendor/sidebar" %>
+    <main class="p-5">
       <div class="flex-1 m-3">
       <%= yield %>
       </div>

--- a/app/views/layouts/vendor.html.erb
+++ b/app/views/layouts/vendor.html.erb
@@ -18,10 +18,9 @@
   </head>
 
   <body>
-    <main class="flex mt-24 p-5">
-      <div class="w-60 m-3">
-        <%= render "vendor/sidebar" %>
-      </div>
+        
+    <main class="mt-24 p-5">
+      <%= render "vendor/sidebar" %>
       <div class="flex-1 m-3">
       <%= yield %>
       </div>

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -1,22 +1,24 @@
-<div class="navbar", style="position: fixed; top: 0; z-index: 1000;">
+<div class="navbar bg-accent", style="position: fixed; top: 0; z-index: 1000;">
   <div class="navbar-start h-5">
     <div class="dropdown" data-controller="sidebar">
-      <div tabindex="0" role="button" class="btn btn-ghost btn-circle" data-action="click->sidebar#toggle">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <div tabindex="0" role="button" class="btn btn-ghost  btn-circle" data-action="click->sidebar#toggle">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
         </svg>
       </div>
       <div data-sidebar-target="menu" class="hidden">
-        <ul tabindex="0" data-sidebar-target="menu" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+        <ul tabindex="0" data-sidebar-target="menu" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow text-stone-600 bg-base-100 rounded-box w-52">
           <%= render "vendor/sidebar" %>
         </ul>
       </div>
     </div>
-    <h1 class="btn btn-ghost text-xl text-orange-900"><%= link_to "RestTime", root_path %></h1>
+    <h1 class="btn btn-ghost text-2xl  text-white"><%= link_to "RestTime", root_path %></h1>
     <div class="badge badge-secondary text-white text-s"><%=t('navbar.vendor_backstage')%></div>
+    <span class="btn btn-ghost text-white"><%= link_to t('navbar.homepage_front'), index_path %></span>
+
   </div>
   <%# 中間文字 %>
-  <div class="flex-none navbar-end">
+  <div class="flex-none navbar-end text-white">
     <ul class="flex menu menu-horizontal px-1">
       <li>
         <details>
@@ -25,7 +27,7 @@
             <li><%= current_user.email %></li>
           </summary>
           <%# 下拉選單 %>
-          <ul class="w-32">
+          <ul class="w-32 text-stone-600 ">
             <li><%= link_to t('navbar.logout'), destroy_user_session_path, data: { turbo_method: "delete" } %></li>
             <li><%= link_to(t('navbar.edit_password'), edit_registration_path(:user)) %></li>
             <% if policy(:shop).index? %>

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar", style="position: fixed; top: 0">
+<div class="navbar", style="position: fixed; top: 0; z-index: 1000;">
   <div class="navbar-start h-5">
     <div class="dropdown" data-controller="sidebar">
       <div tabindex="0" role="button" class="btn btn-ghost btn-circle" data-action="click->sidebar#toggle">

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -1,27 +1,23 @@
 <div class="navbar">
-  <div class="navbar-start">
+  <div class="navbar-start h-5">
     <div class="dropdown" data-controller="sidebar">
       <div tabindex="0" role="button" class="btn btn-ghost btn-circle" data-action="click->sidebar#toggle">
-        <div>
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
-          </svg>
-        </div>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
+        </svg>
       </div>
       <div data-sidebar-target="menu">
-        <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+        <ul tabindex="0" data-sidebar-target="menu" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
           <%= render "vendor/sidebar" %>
         </ul>
       </div>
     </div>
-    <div>
-      <a class="btn btn-ghost text-xl"><%= link_to "RestTime", root_path %></a>
-      <div class="badge badge-secondary text-white text-s">商家後台</div>
-    </div>
+    <h1 class="btn btn-ghost text-xl text-orange-900"><%= link_to "RestTime", root_path %></h1>
+    <div class="badge badge-secondary text-white text-s"><%=t('navbar.vendor_backstage')%></div>
   </div>
   <%# 中間文字 %>
   <div class="flex-none navbar-end">
-    <ul class="flex gap-3 menu menu-horizontal px-1">
+    <ul class="flex menu menu-horizontal px-1">
       <li>
         <details>
           <summary>
@@ -35,7 +31,7 @@
             <% if policy(:shop).index? %>
               <li><%= link_to t('navbar.mybackstage'), vendor_index_path, class: 'text-red-500' %></li>
             <% end %>
-            <li><%= link_to t('My Bookings'), my_bookings_orders_path %></li>
+            <li><%= link_to t('navbar.mybookings'), my_bookings_orders_path %></li>
           </ul>
         </details>
       </li>

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar">
+<div class="navbar", style="position: fixed; top: 0">
   <div class="navbar-start h-5">
     <div class="dropdown" data-controller="sidebar">
       <div tabindex="0" role="button" class="btn btn-ghost btn-circle" data-action="click->sidebar#toggle">

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -1,0 +1,45 @@
+<div class="navbar">
+  <div class="navbar-start">
+    <div class="dropdown">
+      <div tabindex="0" role="button" class="btn btn-ghost btn-circle" data-controller="sidebar">
+        <div data-action="click->sidebar#toggle">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
+        </div>
+      </div>
+      <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+        <div data-sidebar-target="toggleable">
+        <%= render "vendor/sidebar" %>
+        </div>
+      </ul>
+    </div>
+    <div>
+        <a class="btn btn-ghost text-xl">RestTime</a>
+        <div class="badge badge-secondary text-white text-s">商家後台</div>
+    </div>
+  </div>
+  <%# 中間文字 %>
+
+  
+    <div class="flex-none navbar-end">
+        <ul class="flex gap-3 menu menu-horizontal px-1">
+            <li>
+            <details>
+                <summary>
+                <i class="fa-solid fa-user"></i>
+                <li><%= current_user.email %></li>
+                </summary>
+    
+                <%# 下拉選單 %>
+                <ul class="w-32">
+                <li><%= link_to t('navbar.logout'), destroy_user_session_path, data: { turbo_method: "delete" } %></li>
+                <li><%= link_to(t('navbar.edit_password'), edit_registration_path(:user)) %></li>
+                <% if policy(:shop).index? %>
+                    <li><%= link_to t('navbar.mybackstage'), vendor_index_path, class: 'text-red-500' %></li>
+                <% end %>
+                <li><%= link_to t('My Bookings'), my_bookings_orders_path %></li>
+                </ul>
+            </details>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -6,7 +6,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
         </svg>
       </div>
-      <div data-sidebar-target="menu">
+      <div data-sidebar-target="menu" class="hidden">
         <ul tabindex="0" data-sidebar-target="menu" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
           <%= render "vendor/sidebar" %>
         </ul>

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -1,45 +1,44 @@
 <div class="navbar">
   <div class="navbar-start">
-    <div class="dropdown">
-      <div tabindex="0" role="button" class="btn btn-ghost btn-circle" data-controller="sidebar">
-        <div data-action="click->sidebar#toggle">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
+    <div class="dropdown" data-controller="sidebar">
+      <div tabindex="0" role="button" class="btn btn-ghost btn-circle" data-action="click->sidebar#toggle">
+        <div>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
+          </svg>
         </div>
       </div>
-      <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
-        <div data-sidebar-target="toggleable">
-        <%= render "vendor/sidebar" %>
-        </div>
-      </ul>
+      <div data-sidebar-target="menu">
+        <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+          <%= render "vendor/sidebar" %>
+        </ul>
+      </div>
     </div>
     <div>
-        <a class="btn btn-ghost text-xl">RestTime</a>
-        <div class="badge badge-secondary text-white text-s">商家後台</div>
+      <a class="btn btn-ghost text-xl">RestTime</a>
+      <div class="badge badge-secondary text-white text-s">商家後台</div>
     </div>
   </div>
   <%# 中間文字 %>
-
-  
-    <div class="flex-none navbar-end">
-        <ul class="flex gap-3 menu menu-horizontal px-1">
-            <li>
-            <details>
-                <summary>
-                <i class="fa-solid fa-user"></i>
-                <li><%= current_user.email %></li>
-                </summary>
-    
-                <%# 下拉選單 %>
-                <ul class="w-32">
-                <li><%= link_to t('navbar.logout'), destroy_user_session_path, data: { turbo_method: "delete" } %></li>
-                <li><%= link_to(t('navbar.edit_password'), edit_registration_path(:user)) %></li>
-                <% if policy(:shop).index? %>
-                    <li><%= link_to t('navbar.mybackstage'), vendor_index_path, class: 'text-red-500' %></li>
-                <% end %>
-                <li><%= link_to t('My Bookings'), my_bookings_orders_path %></li>
-                </ul>
-            </details>
-            </li>
-        </ul>
-    </div>
+  <div class="flex-none navbar-end">
+    <ul class="flex gap-3 menu menu-horizontal px-1">
+      <li>
+        <details>
+          <summary>
+            <i class="fa-solid fa-user"></i>
+            <li><%= current_user.email %></li>
+          </summary>
+          <%# 下拉選單 %>
+          <ul class="w-32">
+            <li><%= link_to t('navbar.logout'), destroy_user_session_path, data: { turbo_method: "delete" } %></li>
+            <li><%= link_to(t('navbar.edit_password'), edit_registration_path(:user)) %></li>
+            <% if policy(:shop).index? %>
+              <li><%= link_to t('navbar.mybackstage'), vendor_index_path, class: 'text-red-500' %></li>
+            <% end %>
+            <li><%= link_to t('My Bookings'), my_bookings_orders_path %></li>
+          </ul>
+        </details>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -15,7 +15,7 @@
       </div>
     </div>
     <div>
-      <a class="btn btn-ghost text-xl">RestTime</a>
+      <a class="btn btn-ghost text-xl"><%= link_to "RestTime", root_path %></a>
       <div class="badge badge-secondary text-white text-s">商家後台</div>
     </div>
   </div>

--- a/app/views/vendor/_sidebar.html.erb
+++ b/app/views/vendor/_sidebar.html.erb
@@ -1,4 +1,5 @@
 <!-- 側邊欄 -->
+
   <div>
     <ul class="menu bg-base-200 w-56 rounded-box">
       <h2 class="menu-title"><%= t('vendor.my backstage') %></h2>

--- a/app/views/vendor/_sidebar.html.erb
+++ b/app/views/vendor/_sidebar.html.erb
@@ -1,22 +1,22 @@
 <!-- 側邊欄 -->
-<li>
-  <%= link_to t('vendor.system_notification'), '#' %>
-</li>
-<li>
-  <%= link_to t('vendor.my_shop'), vendor_index_path %>
-</li>
-<li>
-  <%= link_to t('vendor.my_product'), my_products_path %>
-  <ul>
-    <li><%= link_to t('vendor.create_product'), new_product_path %></li>
-  </ul>
-</li>
-<li>
-  <%= link_to t('vendor.appointment'), '#' %>
-</li>
-<li>
-  <%= link_to t('vendor.redeem_order'), '#' %>
-</li>
-<li>
-  <%= link_to t('vendor.message'), '#' %>
-</li>
+  <div>
+      <h2 class="menu-title"><%= t('vendor.my backstage') %></h2>
+      <li>
+        <%= link_to t('vendor.system notification'), '#' %>
+      </li>
+      <li>
+        <%= link_to  t('vendor.my shop'), vendor_index_path%>
+      </li>
+      <li>
+        <%= link_to  t('vendor.my product'), my_products_path%>
+        <ul>
+          <li><%= link_to t('vendor.create product'), new_product_path %></li>
+        </ul>
+      </li>
+      <li>
+        <%= link_to t('vendor.my order'), my_vendor_orders_path %>
+      </li>
+      <li>
+        <%= link_to t('vendor.message'), '#' %>
+      </li>
+  </div>

--- a/app/views/vendor/_sidebar.html.erb
+++ b/app/views/vendor/_sidebar.html.erb
@@ -1,25 +1,22 @@
 <!-- 側邊欄 -->
-
-  <div>
-    <ul class="menu bg-base-200 w-56 rounded-box">
-      <h2 class="menu-title"><%= t('vendor.my backstage') %></h2>
-      <li>
-        <%= link_to t('vendor.system notification'), '#' %>
-      </li>
-      <li>
-        <%= link_to  t('vendor.my shop'), vendor_index_path%>
-      </li>
-      <li>
-        <%= link_to  t('vendor.my product'), my_products_path%>
-        <ul>
-          <li><%= link_to t('vendor.create product'), new_product_path %></li>
-        </ul>
-      </li>
-      <li>
-        <%= link_to t('vendor.my order'), my_vendor_orders_path %>
-      </li>
-      <li>
-        <%= link_to t('vendor.message'), '#' %>
-      </li>
-    </ul>
-  </div>
+<li>
+  <%= link_to t('vendor.system_notification'), '#' %>
+</li>
+<li>
+  <%= link_to t('vendor.my_shop'), vendor_index_path %>
+</li>
+<li>
+  <%= link_to t('vendor.my_product'), my_products_path %>
+  <ul>
+    <li><%= link_to t('vendor.create_product'), new_product_path %></li>
+  </ul>
+</li>
+<li>
+  <%= link_to t('vendor.appointment'), '#' %>
+</li>
+<li>
+  <%= link_to t('vendor.redeem_order'), '#' %>
+</li>
+<li>
+  <%= link_to t('vendor.message'), '#' %>
+</li>

--- a/app/views/vendor/index.html.erb
+++ b/app/views/vendor/index.html.erb
@@ -1,4 +1,5 @@
-<h1><%= t('form.shop.update') %></h1>
+<p><%= t('views.shop.index.title') %></p>
+
 <ul class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
   <%= render 'shops/form', shop: @shop %>
 </ul>

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -13,6 +13,12 @@ tw:
     privacy:
       title: 隱私權政策
     shop info: 商店資訊
+    edit_password: 修改密碼
+    mybackstage: 我的後台
+    mybookings: 我的預定
+    vendor_backstage: 商家後台
+
+
   
   home: 首頁
   my bookings: 我的預約 

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -9,6 +9,7 @@ tw:
     my backstage: 我的後台
     vendor: 商家
     homepage: 首頁
+    homepage_front: 前台首頁
     page:
     privacy:
       title: 隱私權政策

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   # Global scope with locale parameter
   scope '(:lang)', locale: /en|tw/ do
-    root 'products#index'
+    root 'pages#index'
 
     resources :products do
       collection do


### PR DESCRIPTION
- 新增後台專屬nav_bar
- 功能鍵在左側上方，可隱藏
- 按logo可至前台首頁
影片範例：

https://github.com/astrocamp/15th-RestTime/assets/147526390/bbe39664-85dc-4022-a2a4-e3b9705dd5db

- 更新：
- 後台navbar新增前台首頁按鈕，按了可以到前台
- navbar添加底色區別
- 增加yml & 縮排
<img width="1434" alt="截圖 2024-01-08 下午6 18 27" src="https://github.com/astrocamp/15th-RestTime/assets/147526390/8c3ac906-0857-4b11-a1ea-715f7d057cfd">







