### PR TITLE
前台訂單詳細頁面排版Feat issue 131

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -47,3 +47,7 @@ figure.attachment img {
 .order_table_td {
   @apply px-5 py-2 text-lg text-center text-gray-500 font-semibold;
 }
+
+.order_text {
+  @apply font-medium mb-2 text-gray-600;
+}

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -5,4 +5,8 @@ module OrdersHelper
     end_time = booking.service_date + booking.product.service_min.minutes
     format_time_without_sec(end_time)
   end
+
+  def render_steps(order)
+    render "#{order.status}"
+  end
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -7,6 +7,6 @@ module OrdersHelper
   end
 
   def render_steps(order)
-    render "#{order.status}"
+    render order.status.to_s
   end
 end

--- a/app/javascript/controllers/qrcode_controller.js
+++ b/app/javascript/controllers/qrcode_controller.js
@@ -9,10 +9,10 @@ export default class extends Controller {
         this.element,
         text,
         {
-          width: 300,
+          width: 200,
           margin: 1,
           color: {
-            light: "#FEF9C3",
+            light: "#ffff",
           },
         },
         (err) => {

--- a/app/views/orders/_cancelled.html.erb
+++ b/app/views/orders/_cancelled.html.erb
@@ -1,0 +1,12 @@
+<li data-content="1" class="step step-neutral">
+  <%= t('order.established') %><br>
+</li>
+<li data-content="2" class="step step-neutral">
+  <%= t("aasm.order state.#{@order.status}") %>
+</li>
+<li data-content="3" class="step step-neutral text-orange-700">
+  <%= t('order.cancelled') %>
+</li>
+<li data-content="4" class="step text-gray-400">
+  <%= t('order.refund') %>
+</li>

--- a/app/views/orders/_completed.html.erb
+++ b/app/views/orders/_completed.html.erb
@@ -1,0 +1,12 @@
+<li data-content="1" class="step step-neutral">
+  <%= t('order.established') %><br>
+</li>
+<li data-content="2" class="step step-neutral">
+  <%= t("aasm.order state.#{@order.status}") %>
+</li>
+<li data-content="3" class="step step-neutral">
+  <%= t('message.order_has_been_redeemed') %>
+</li>
+<li data-content="★" class="step step-neutral text-orange-700">
+  <%= t('order.completed') %>
+</li>

--- a/app/views/orders/_paid.html.erb
+++ b/app/views/orders/_paid.html.erb
@@ -1,0 +1,12 @@
+<li data-content="1" class="step step-neutral">
+  <%= t('order.established') %><br>
+</li>
+<li data-content="2" class="step step-neutral">
+  <%= t("aasm.order state.#{@order.status}") %>
+</li>
+<li data-content="3" class="step text-orange-700">
+  <button><%= t('order.restime_now') %></button>
+</li>
+<li data-content="4" class="step text-gray-400">
+  <%= t('order.completed') %>
+</li>

--- a/app/views/orders/_pending.html.erb
+++ b/app/views/orders/_pending.html.erb
@@ -1,0 +1,12 @@
+<li data-content="1" class="step step-neutral">
+  <%= t('order.established') %><br>
+</li>
+<li data-content="2" class="step step-neutral">
+  <%= t("aasm.order state.#{@order.status}") %>
+</li>
+<li data-content="3" class="step text-orange-700">
+  <%= t('order.please_pay') %>
+</li>
+<li data-content="4" class="step text-gray-400">
+  <%= t('order.completed') %>
+</li>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,8 +1,8 @@
 <div class="text-sm breadcrumbs">
   <ul>
     <li><%= link_to t('home'), root_path %></li>
-    <li><%= link_to t('my bookings'), my_bookings_orders_path %></li>
-    <li><%= link_to t('order.order_info'), '#' %></li>
+    <li><%= link_to t('my_bookings'), my_bookings_orders_path %></li>
+    <li><%= t('order.order_info') %></li>
   </ul>
 </div>
 
@@ -28,22 +28,24 @@
             </iframe>
           </div>
         </li>
-        <div class="grid grid-cols-4 gap-2">
+        <div class="grid grid-cols-4 gap-2 p-2">
           <div class="col-span-2">
             <ul>
               <li class="mb-4">
-                <h2 class="text-2xl font-bold mb-3"><%= t('views.shop.show.information') %></h2>
+                <h2 class="text-2xl font-bold mb-3 text-gray-700">
+                  <%= t('views.shop.show.information') %>
+                </h2>
               </li>
-              <li class="text-lg font-medium mb-2">
+              <li class="text-lg order_text">
                 <%= @order.shop.title %>
               </li>
-              <li class="text-m font-medium mb-2">
+              <li class="text-m order_text">
                 <%= @order.shop.description %>
               </li>
-              <li class="text-lg font-medium mb-2">
+              <li class="text-lg order_text">
                 <%= @order.shop.tel %>
               </li>
-              <li class="text-lg font-medium mb-2">
+              <li class="text-lg order_text">
                 <%= address(@order.shop) %>
               </li>
             </ul>
@@ -51,35 +53,35 @@
           <div class="col-span-2 mx-auto">
             <ul>
               <li class="mb-4">
-                <h2 class="text-2xl font-bold mb-3">
+                <h2 class="text-2xl font-bold mb-3 text-gray-700">
                   <%= t('service_times.title') %>
                 </h2>
               </li>
-              <li class="text-m font-medium mb-2">
+              <li class="text-m order_text">
                 <%= t('service_times.monday') %> ： 
                 <%= t('service_times.off_day') %>
               </li>
-              <li class="text-m font-medium mb-2">
+              <li class="text-m order_text">
                 <%= t('service_times.tuesday') %> 
                 ： 11:00 － 23:00
               </li>
-              <li class="text-m font-medium mb-2">
+              <li class="text-m order_text">
                 <%= t('service_times.wednesday') %> ： 
                 <%= t('service_times.off_day') %>
               </li>
-              <li class="text-m font-medium mb-2">
+              <li class="text-m order_text">
                 <%= t('service_times.thursday') %> 
                 ： 11:00 － 23:00
               </li>
-              <li class="text-m font-medium mb-2">
+              <li class="text-m order_text">
                 <%= t('service_times.friday') %> 
                 ： 11:00 － 23:00
               </li>
-              <li class="text-m font-medium mb-2">
+              <li class="text-m order_text">
                 <%= t('service_times.saturday') %> 
                 ： 11:00 － 23:00
               </li>
-              <li class="text-m font-medium mb-2">
+              <li class="text-m order_text">
                 <%= t('service_times.sunday') %> 
                 ： 11:00 － 23:00
               </li>
@@ -99,14 +101,13 @@
           </table>
           <div>
           <% unless @order.completed? || @order.cancelled? %>
-            <div class="mt-4 w-full bg-red-400 hover:bg-red-250 text-black font-semibold font-bold py-2 px-2 rounded focus:outline-none focus:shadow-outline font-medium text-center">
-              <%= link_to t('order.appointment_change'), edit_order_path(@order), class: "block w-full" %>
+            <div class="mt-4 w-full bg-accent text-black font-semibold font-bold py-3 px-2 rounded font-medium text-center rounded-xl text-white">
+              <%= link_to t('order.appointment_change'), edit_order_path(@order) %>
             </div>
           <% end %>
           <% if @order.may_cancel? %>
-          <div class="mt-4 mb-4 w-full bg-red-400 hover:bg-red-250 text-black font-semibold font-bold py-2 px-2 rounded focus:outline-none focus:shadow-outline font-medium text-center">
+          <div class="mt-4 mb-4 w-full bg-gray-400 text-black font-semibold font-bold py-3 px-2 rounded font-medium text-center rounded-xl text-white">
             <%= link_to t('order.cancel_order'), cancel_order_path(@order),
-              class: "block w-full",
               data: { turbo_method: 'patch',
               turbo_confirm: t('message.are_you_sure_cancel_order') } %>
           </div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,95 +1,181 @@
 <div class="text-sm breadcrumbs">
   <ul>
-    <li><%= link_to t('home'), root_path %></li> 
-    <li><%= link_to t('my_bookings'), my_bookings_orders_path %></li>
+    <li><%= link_to t('home'), root_path %></li>
+    <li><%= link_to t('my bookings'), my_bookings_orders_path %></li>
+    <li><%= link_to t('order.order_info'), '#' %></li>
   </ul>
 </div>
 
-<div class="flex flex-row justify-between">
-  <div tabindex="0" class="collapse bg-primary text-primary-content focus:bg-secondary focus:text-secondary-content flex-1">
-    <div class="collapse-title">
-      <div><%= t('order.qrcode') %></div>
-    </div>
-    <div class="collapse-content"> 
-      <canvas data-controller="qrcode" data-text="<%= @url_string %>"></canvas>
-    </div>
-  </div>
-
-  <div tabindex="0" class="collapse bg-primary text-primary-content focus:bg-secondary focus:text-secondary-content flex-1 ml-4">
-    <div class="collapse-title">
-      <div><%= t('order.google_map') %></div>
-    </div>
-    <div class="collapse-content"> 
-      <iframe
-        width="710"
-        height="300"
-        frameborder="0" style="border:0"
-        referrerpolicy="no-referrer-when-downgrade"
-        src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['GOOGLE_API_KEY'] %>&q=<%= ERB::Util.url_encode(address(@shop)) %>"
-        allowfullscreen>
-      </iframe>
-    </div>
-  </div>
-</div>
-
-<div class="grid grid-cols-2 gap-4 mt-8">
-  <div>
-    <div class="card w-full bg-white-100 shadow-xl">
-      <div class="card-body gap-4">
-        <div class="card-title"><%= t('order.booking_info') %></div>
-        <div class="flex justify-between">
-          <span><%= @order.product.title %><%= @order.service_min %><%= t('order.min') %></span>
-          <span><%= t('order.currency') %> <%= @order.price.to_i %></span>
-        </div>
-        <table class="table text-center">
-          <thead>
-            <tr class="border-2 border-gray-500">
-              <th><%= t('order.booking_date') %></th>
-              <th><%= t('order.booking_start_time') %></th>
-              <th><%= t('order.booking_end_time') %></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><%= format_date(@order.service_date) %></td>
-              <td><%= format_time_without_sec(@order.service_date) %></td>
-              <td><%= booking_end_time(@order) %></td>
-            </tr>
-          </tbody>
-        </table>
-        <div class="flex justify-between border-2  border-gray-500 p-4">
-          <span><%= t('order.total') %></span>
-          <span><%= t('order.currency') %> <%= @order.price.to_i %></span>
-        </div>        
-      </div>
-    </div>
-    <div class="card w-full bg-white-100 shadow-xl">
-      <div class="card-body gap-4">
-        <div class="card-title"><%= t('order.contact_info') %></div>
-        <div class="flex">
-          <%= tag.label t('order.name'), class: 'label' %>
-          <%= tag.label @order.booked_name, class: 'label' %>
-        </div>
-        <div class="flex">
-          <%= tag.label 'Email', class: 'label' %>
-          <%= tag.label @order.booked_email, class: 'label' %>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div class="card w-full bg-white-100 shadow-xl">
+<section class="container mx-auto p-5">
+  <div class="h-[300px] relative">
+    <article class="mt-4 z-10 absolute top-64 left-10 text-white">
+      <h1 class="text-xl font-bold"><%= @order.shop.title %></h1>
+    </article>
+    <div class="absolute h-[300px] overflow-hidden place-items-center">
       <% if @order.shop.cover.attached? %>
-        <figure><%= image_tag @order.shop.cover, class: "w-full h-[300px]" %></figure>
+        <%= image_tag @order.shop.cover, class: "w-full -translate-y-1/4 brightness-50" %>
       <% else %>
-        <figure><img src="https://fakeimg.pl/1000x300/200" class="w-full h-[300px]"></figure>
+        <img src="https://fakeimg.pl/1000x300/200" class="w-full">
       <% end %>
-      <div class="card-body gap-4">
-        <div class="card-title">
-            <p><%= @order.shop.title %></p>
-            <span><%= @order.product.title %><%= @order.service_min %><%= t('order.min') %></span>
+    </div>
+  </div>
+  <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+    <div class="card md:col-span-2 bg-white-100 shadow-xl">
+      <ul class="card-body mx-10">
+        <li class="text-lg font-medium mb-3">
+          <div class="aspect-w-16 aspect-h-9 w-full max-w-full">
+            <iframe class="w-full h-full border-0 rounded-lg" frameborder="0" referrerpolicy="no-referrer-when-downgrade" src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['GOOGLE_API_KEY'] %>&q=<%= ERB::Util.url_encode(address(@shop)) %>" allowfullscreen>
+            </iframe>
+          </div>
+        </li>
+        <div class="grid grid-cols-4 gap-2">
+          <div class="col-span-2">
+            <ul>
+              <li class="mb-4">
+                <h2 class="text-2xl font-bold mb-3"><%= t('views.shop.show.information') %></h2>
+              </li>
+              <li class="text-lg font-medium mb-2">
+                <%= @order.shop.title %>
+              </li>
+              <li class="text-m font-medium mb-2">
+                <%= @order.shop.description %>
+              </li>
+              <li class="text-lg font-medium mb-2">
+                <%= @order.shop.tel %>
+              </li>
+              <li class="text-lg font-medium mb-2">
+                <%= address(@order.shop) %>
+              </li>
+            </ul>
+          </div>
+          <div class="col-span-2 mx-auto">
+            <ul>
+              <li class="mb-4">
+                <h2 class="text-2xl font-bold mb-3">
+                  <%= t('service_times.title') %>
+                </h2>
+              </li>
+              <li class="text-m font-medium mb-2">
+                <%= t('service_times.monday') %> ： 
+                <%= t('service_times.off_day') %>
+              </li>
+              <li class="text-m font-medium mb-2">
+                <%= t('service_times.tuesday') %> 
+                ： 11:00 － 23:00
+              </li>
+              <li class="text-m font-medium mb-2">
+                <%= t('service_times.wednesday') %> ： 
+                <%= t('service_times.off_day') %>
+              </li>
+              <li class="text-m font-medium mb-2">
+                <%= t('service_times.thursday') %> 
+                ： 11:00 － 23:00
+              </li>
+              <li class="text-m font-medium mb-2">
+                <%= t('service_times.friday') %> 
+                ： 11:00 － 23:00
+              </li>
+              <li class="text-m font-medium mb-2">
+                <%= t('service_times.saturday') %> 
+                ： 11:00 － 23:00
+              </li>
+              <li class="text-m font-medium mb-2">
+                <%= t('service_times.sunday') %> 
+                ： 11:00 － 23:00
+              </li>
+            </ul>
+          </div>
+        </div>
+      </ul>
+    </div>
+    <div class="card md:col-span-2 bg-white-100 shadow-xl">
+      <div class="card-body">
+        <ul class="steps mt-12 mb-12">
+          <%= render_steps(@order) %>
+        </ul>
+        <div class="overflow-x-auto mb-10 ml-12 mr-12">
+          <table class="min-w-full table-auto border-collapse bg-slate-100 shadow-lg text-lg text-gray-800 rounded-lg overflow-hidden">
+            <thead class="bg-gray-300">
+              <tr>
+                <th class="px-4 py-2 border-b-2 text-left text-gray-600 rounded-tl-lg">
+                  <%= t('order.booking_item') %>
+                </th>
+                <th class="px-4 py-2 border-b-2 text-left text-gray-600">
+                  <%= t('order.booking_date') %>
+                </th>
+                <th class="px-4 py-2 border-b-2 text-left text-gray-600 rounded-tr-lg">
+                  <%= t('order.time_start_end') %>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="px-4 py-2 border-b rounded-bl-lg">
+                  <%= truncate(@order.product.title, length: 13) %>
+                </td>
+                <td class="px-4 py-2 border-b">
+                  <%= format_date(@order.service_date) %>
+                </td>
+                <td class="px-4 py-2 border-b rounded-br-lg">
+                  <%= "#{format_time_without_sec(@order.service_date)}－#{booking_end_time(@order)}" %>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="mr-12 ml-12">
+          <% unless @order.completed? || @order.cancelled? %>
+            <div class="border border-base-200 rounded-md p-4 mb-4 font-bold text-lg font-medium text-center ">
+              <%= link_to t('order.appointment_change'), '#', class: "block w-full" %>
+              <%#= link_to t('order.appointment_change'), edit_order_path(@order), class: "block w-full" feat-issue-28才有此路徑%>
+            </div>
+          <% end %>
+          <% if @order.may_cancel? %>
+          <div class="border border-base-200 rounded-md p-4 mb-4 font-bold text-lg font-medium text-center">
+            <%= link_to t('order.cancelled'), '#', class: "block w-full"  %>
+            <%#= link_to t('order.cancel_order'), cancel_order_path(@order), class: "block w-full"  feat-issue-28才有此路徑%>
+          </div>
+          <% end %>
+        </div>
+
+        <div class="mr-12 ml-12">
+          <div tabindex="0" class="collapse collapse-plus border border-base-200 bg-gray-200 mb-5 px-5">
+            <div class="collapse-title text-lg font-medium ">
+              <h3 class="text-center px-5"><%= t('order.faqs') %></h3>
+            </div>
+            <div class="collapse-content"> 
+              <div class="p-3">
+                <h4 class="text-center underline mb-2 font-bold">
+                  <%= t('faqs.order.title.redemption') %>
+                </h4>
+                <p class="mb-1 text-gray-500">★ 您可以通過我們的系統或應用選擇您需要的服務或活動進行預約。系統會為您的預約生成一個獨特的QR碼，用於後續的核銷程序。</p>
+                <p class="mb-1 text-gray-500">★ 在預約的日期和時間，請攜帶您的QR碼前往預約地點。到達預約地點時，向工作人員出示您的QR碼。工作人員將使用專業設備掃描您的QR碼，確認完您的身分，進行核銷。</p>
+              </div>
+              <div class="p-3">
+                <h4 class="text-center underline mb-3 font-bold">
+                  <%= t('faqs.order.title.redemption_notice') %>
+                </h4>
+                <p class="mb-1 text-gray-500">★ 請確保您的QR碼清晰可見，以便快速掃描。</p>
+                <p class="mb-1 text-gray-500">★ 請妥善保管您的QR碼，若經外人使用核銷，恕不能重複使用及退費。</p>
+                <p class="mb-1 text-gray-500">★ 如果您遇到任何問題，請即時與我們的工作人員聯繫。</p>
+              </div>
+            </div>
+          </div>
+          
+          <% if @order.paid? %>
+            <div tabindex="0" class="collapse collapse-plus border border-base-200 bg-gray-200">
+              <div class="collapse-title text-lg font-medium text-center flex justify-center">
+                <h3><%= t('order.redeeming') %></h3>
+              </div>
+              <ul class="collapse-content flex justify-center"> 
+                <div class="">
+                  <canvas data-controller="qrcode" data-text="<%= @url_string %>"></canvas>
+                </div>
+              </ul>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>
   </div>
-</div>
+</section>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -125,14 +125,14 @@
         </div>
         <div class="mr-12 ml-12">
           <% unless @order.completed? || @order.cancelled? %>
-            <div class="border border-base-200 rounded-md p-4 mb-4 font-bold text-lg font-medium text-center ">
-              <%= link_to t('order.appointment_change'), '#', class: "block w-full" %>
+            <div class="mt-4 w-full bg-red-400 hover:bg-red-250 text-black font-semibold font-bold py-2 px-2 rounded focus:outline-none focus:shadow-outline font-medium text-center">
+              <%= link_to t('order.appointment_change'), '#' %>
               <%#= link_to t('order.appointment_change'), edit_order_path(@order), class: "block w-full" feat-issue-28才有此路徑%>
             </div>
           <% end %>
           <% if @order.may_cancel? %>
-          <div class="border border-base-200 rounded-md p-4 mb-4 font-bold text-lg font-medium text-center">
-            <%= link_to t('order.cancelled'), '#', class: "block w-full"  %>
+          <div class="mt-4 mb-4 w-full bg-red-400 hover:bg-red-250 text-black font-semibold font-bold py-2 px-2 rounded focus:outline-none focus:shadow-outline font-medium text-center">
+            <%= link_to t('order.cancelled'), '#'  %>
             <%#= link_to t('order.cancel_order'), cancel_order_path(@order), class: "block w-full"  feat-issue-28才有此路徑%>
           </div>
           <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -100,14 +100,15 @@
           <div>
           <% unless @order.completed? || @order.cancelled? %>
             <div class="mt-4 w-full bg-red-400 hover:bg-red-250 text-black font-semibold font-bold py-2 px-2 rounded focus:outline-none focus:shadow-outline font-medium text-center">
-              <%= link_to t('order.appointment_change'), '#' %>
-              <%#= link_to t('order.appointment_change'), edit_order_path(@order), class: "block w-full" feat-issue-28才有此路徑%>
+              <%= link_to t('order.appointment_change'), edit_order_path(@order), class: "block w-full" %>
             </div>
           <% end %>
           <% if @order.may_cancel? %>
           <div class="mt-4 mb-4 w-full bg-red-400 hover:bg-red-250 text-black font-semibold font-bold py-2 px-2 rounded focus:outline-none focus:shadow-outline font-medium text-center">
-            <%= link_to t('order.cancelled'), '#'  %>
-            <%#= link_to t('order.cancel_order'), cancel_order_path(@order), class: "block w-full"  feat-issue-28才有此路徑%>
+            <%= link_to t('order.cancel_order'), cancel_order_path(@order),
+              class: "block w-full",
+              data: { turbo_method: 'patch',
+              turbo_confirm: t('message.are_you_sure_cancel_order') } %>
           </div>
           <% end %>
         </div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -23,7 +23,7 @@
     <div class="card md:col-span-2 bg-white-100 shadow-xl">
       <ul class="card-body mx-10">
         <li class="text-lg font-medium mb-3">
-          <div class="aspect-w-16 aspect-h-9 w-full max-w-full">
+          <div class="aspect-w-16 aspect-h-9 w-full max-w-full mb-6">
             <iframe class="w-full h-full border-0 rounded-lg" frameborder="0" referrerpolicy="no-referrer-when-downgrade" src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['GOOGLE_API_KEY'] %>&q=<%= ERB::Util.url_encode(address(@shop)) %>" allowfullscreen>
             </iframe>
           </div>
@@ -93,37 +93,11 @@
         <ul class="steps mt-12 mb-12">
           <%= render_steps(@order) %>
         </ul>
-        <div class="overflow-x-auto mb-10 ml-12 mr-12">
-          <table class="min-w-full table-auto border-collapse bg-slate-100 shadow-lg text-lg text-gray-800 rounded-lg overflow-hidden">
-            <thead class="bg-gray-300">
-              <tr>
-                <th class="px-4 py-2 border-b-2 text-left text-gray-600 rounded-tl-lg">
-                  <%= t('order.booking_item') %>
-                </th>
-                <th class="px-4 py-2 border-b-2 text-left text-gray-600">
-                  <%= t('order.booking_date') %>
-                </th>
-                <th class="px-4 py-2 border-b-2 text-left text-gray-600 rounded-tr-lg">
-                  <%= t('order.time_start_end') %>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td class="px-4 py-2 border-b rounded-bl-lg">
-                  <%= truncate(@order.product.title, length: 13) %>
-                </td>
-                <td class="px-4 py-2 border-b">
-                  <%= format_date(@order.service_date) %>
-                </td>
-                <td class="px-4 py-2 border-b rounded-br-lg">
-                  <%= "#{format_time_without_sec(@order.service_date)}－#{booking_end_time(@order)}" %>
-                </td>
-              </tr>
-            </tbody>
+        <div class="overflow-x-auto mb-10 ml-12 mr-12 mt-6">
+          <table class="min-w-full table-auto border-collapse bg-slate-100 shadow-lg text-lg text-gray-800 rounded-lg overflow-hidden mb-8">
+            <%= render 'order_table' %>
           </table>
-        </div>
-        <div class="mr-12 ml-12">
+          <div>
           <% unless @order.completed? || @order.cancelled? %>
             <div class="mt-4 w-full bg-red-400 hover:bg-red-250 text-black font-semibold font-bold py-2 px-2 rounded focus:outline-none focus:shadow-outline font-medium text-center">
               <%= link_to t('order.appointment_change'), '#' %>
@@ -137,11 +111,13 @@
           </div>
           <% end %>
         </div>
-
-        <div class="mr-12 ml-12">
+      </div>
+      <div class="mr-12 ml-12">
           <div tabindex="0" class="collapse collapse-plus border border-base-200 bg-gray-200 mb-5 px-5">
             <div class="collapse-title text-lg font-medium ">
-              <h3 class="text-center px-5"><%= t('order.faqs') %></h3>
+              <h3 class="text-center px-5">
+                <%= t('order.faqs') %>
+              </h3>
             </div>
             <div class="collapse-content"> 
               <div class="p-3">
@@ -174,7 +150,7 @@
               </ul>
             </div>
           <% end %>
-        </div>
+      </div>
       </div>
     </div>
   </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar bg-base-100 shadow-md p-1 fixed w-full top-0 z-10 mb-11">
+<nav class="navbar bg-base-100 shadow-md p-1 fixed w-full top-0 z-20 mb-11">
   <div class="flex-1">
     <h1 class="btn btn-ghost text-3xl text-orange-900"><%= link_to "RestTime", root_path %></h1>
       <span class="btn btn-ghost hover:bg-accent text-slate-700"><%= link_to t('navbar.homepage'), index_path %></span>

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -135,8 +135,8 @@ tw:
     booking: 開始預約
     booking_date: 預約日期
     booking time slot: 預約時段
-    booking start time: 開始時間
-    booking end time: 結束時間
+    booking_start_time: 開始時間
+    booking_end_time: 結束時間
     contact info: 聯絡資訊
     booking info: 預約資訊
     booking_item: 預約項目
@@ -151,6 +151,7 @@ tw:
     status: 訂單狀態
     updated_status_time: 狀態更新時間 
     serial: 訂單編號
+    order_price: 訂單金額
     created_date: 訂單建立日期
     price: 消費金額
     order_price: 訂單金額

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -141,8 +141,8 @@ tw:
     booking info: 預約資訊
     booking_item: 預約項目
     order_info: 訂單資訊
-    customer info: 客戶資訊
-    service duration: 服務時間
+    customer_info: 客戶資訊
+    service_duration: 服務時間
     established: 訂單成立
     name: 姓名
     email: 信箱

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -134,15 +134,16 @@ tw:
     currency: NTD
     booking: 開始預約
     booking_date: 預約日期
-    booking_time_slot: 預約時段
-    booking_start_time: 開始時間
-    booking_end_time: 結束時間
-    contact_info: 聯絡資訊
-    booking_info: 預約資訊
+    booking time slot: 預約時段
+    booking start time: 開始時間
+    booking end time: 結束時間
+    contact info: 聯絡資訊
+    booking info: 預約資訊
     booking_item: 預約項目
     order_info: 訂單資訊
-    customer_info: 客戶資訊
-    service_duration: 服務時間
+    customer info: 客戶資訊
+    service duration: 服務時間
+    established: 訂單成立
     name: 姓名
     email: 信箱
     total: 總計
@@ -159,18 +160,27 @@ tw:
     redeem_order: 核銷訂單
     staff: 核銷人員
     start_end: (開始時間~結束時間)
+
     time_start_end: 開始時間－結束時間
     choose_product: 選擇項目
     appointment_change: 變更預約
     chang_booking_time: 更改預約時間
+    appointment_change: 更改預約時間
     reschedule_the_booking_time: 重新選擇預約時段
     cancel_order: 取消訂單
     pay: 付款
     payment_method: 付款方式
     service_time: 消費時數
     service_time_min: "消費時數: %{service_min} 分鐘"
+    please_pay: 請先付款
+    restime_now: 開始享樂
+    completed: 完成訂單
+    cancelled: 取消訂單
+    refund: 待退款
+    redeeming: 進行核銷
+    faqs: 常見問題
   message:
-    the system is busy, please try again later: 系統忙碌中，請稍候再試
+    The system is busy, please try again later: 系統忙碌中，請稍候再試
     appointment_successful: 預約成功
     please_confirm_again: 訂單即將核銷，請再次確認！
     order_has_been_redeemed: 訂單已核銷
@@ -295,3 +305,8 @@ tw:
     change_booking_time: "Hello,Here is ResTime，%{booked_name}先生/女士的預約時間已經更改%{service_date}，請儘快確認您的訂單。"
     order_redeemed: "Hello,Here is ResTime，訂單編號<%{serial}>已經核銷，麻煩再確認您的訂單內容。"
     order_cancelled: "Hello,Here is ResTime，訂單編號<%{serial}>已經取消，麻煩再確認您的訂單內容。"
+  faqs:
+    order:
+      title:
+        redemption: 預約使用核銷說明
+        redemption_notice: 核銷注意

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -134,11 +134,11 @@ tw:
     currency: NTD
     booking: 開始預約
     booking_date: 預約日期
-    booking time slot: 預約時段
+    booking_time_slot: 預約時段
     booking_start_time: 開始時間
     booking_end_time: 結束時間
-    contact info: 聯絡資訊
-    booking info: 預約資訊
+    contact_info: 聯絡資訊
+    booking_info: 預約資訊
     booking_item: 預約項目
     order_info: 訂單資訊
     customer_info: 客戶資訊

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -181,7 +181,7 @@ tw:
     redeeming: 進行核銷
     faqs: 常見問題
   message:
-    The system is busy, please try again later: 系統忙碌中，請稍候再試
+    the system is busy, please try again later: 系統忙碌中，請稍候再試
     appointment_successful: 預約成功
     please_confirm_again: 訂單即將核銷，請再次確認！
     order_has_been_redeemed: 訂單已核銷


### PR DESCRIPTION
- 基本切版
- 增加判斷畫面顯示
- 依照aasm四種訂單狀態render個別區塊
  - 目前畫面：
![截圖 2024-01-07 晚上10 16 59](https://github.com/astrocamp/15th-RestTime/assets/114802512/b09e5601-053d-4437-9889-fe8e28638947)
![截圖 2024-01-07 晚上10 24 10](https://github.com/astrocamp/15th-RestTime/assets/114802512/185e8295-48b6-4237-9905-cdd9b7a5ffbf)
![截圖 2024-01-07 晚上10 25 03](https://github.com/astrocamp/15th-RestTime/assets/114802512/ebf4b544-45f5-46b2-a3e9-9bb2ce0ea04b)
![截圖 2024-01-07 晚上10 27 31](https://github.com/astrocamp/15th-RestTime/assets/114802512/0b890bdd-46a6-4d9b-9b27-f7ef87761303)
- 替換修改訂單資訊
![截圖 2024-01-08 晚上11 57 49](https://github.com/astrocamp/15th-RestTime/assets/114802512/27a96c0e-4ce0-4396-8453-ff63454835d8)
![截圖 2024-01-09 凌晨12 01 04](https://github.com/astrocamp/15th-RestTime/assets/114802512/3165eaac-9fee-421c-a7e9-bde378e8972c)


- 營業時間尚未連結，討論後再開卡帶入
- 修改以及刪除路徑等分支feat-issue-28過了再修正(已備註) 

