### PR TITLE
調整主色彩 Issue 117

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -9,7 +9,7 @@
 }
 
 .flash-notice {
-  @apply px-4 py-2 text-white bg-primary;
+  @apply px-4 py-2 text-white bg-warning;
 }
 
 /* 留言區的圖片設定嘴大寬高限制 */

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -5,11 +5,11 @@
 @tailwind utilities;
 
 .flash-alert {
-  @apply px-4 py-2 text-white bg-rose-700;
+  @apply px-4 py-2 bg-error;
 }
 
 .flash-notice {
-  @apply px-4 py-2 text-white bg-accent;
+  @apply px-4 py-2 text-white bg-primary;
 }
 
 /* 留言區的圖片設定嘴大寬高限制 */

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -9,7 +9,7 @@
 }
 
 .flash-notice {
-  @apply px-4 py-2 text-white bg-warning;
+  @apply px-4 py-2 text-white bg-primary;
 }
 
 /* 留言區的圖片設定嘴大寬高限制 */

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
-
 module Users
   class SessionsController < Devise::SessionsController
+    before_action :configure_permitted_parameters, if: :devise_controller?
+
+    def after_sign_in_path_for(resource)
+      if resource.vendor?
+        vendor_index_path
+      else
+        super
+      end
+    end
     # before_action :configure_permitted_parameters, if: :devise_controller?
 
     # GET /resource/sign_in
@@ -22,5 +30,8 @@ module Users
     #   devise_parameter_sanitizer.permit(:account_update, keys: added_attrs)
     #   devise_parameter_sanitizer.permit(:sign_in, keys: added_attrs)
     # end
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_in, keys: [:role])
+    end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="autumn">
+<html data-theme="frontstage">
   <head>
     <title>RestTime</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="frontstage">
+<html data-theme="mytheme">
   <head>
     <title>RestTime</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -13,11 +13,11 @@
   </head>
 
   <body>
+    <div class="mb-16">
     <%= render "shared/navbar" %>
-    <div class="mt-16">
-    <%= render "shared/flash" if flash.any? %>
     </div>
-    <main class="container p-8 mt-24 mx-auto">
+    <%= render "shared/flash" if flash.any? %>
+    <main class="container p-8 mx-auto">
       <%= yield %>
     </main>
     <%= render "shared/footer" %>

--- a/app/views/layouts/vendor.html.erb
+++ b/app/views/layouts/vendor.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="backstage">
+<html data-theme="mytheme">
   <head>
     <title>RestTime</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -10,19 +10,15 @@
     <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
     
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    <div class="mb-24">
-      <%= render "vendor/navbar" %>
-    </div>
-    </div>
-    <%= render "shared/flash" if flash.any? %>
-    </div>
   </head>
 
   <body>
-    <main class="p-5">
-      <div class="flex-1 m-3">
+    <div class="mb-16">
+      <%= render "vendor/navbar" %>
+    </div>
+    <%= render "shared/flash" if flash.any? %>
+    <main class="container p-8 mx-auto">
       <%= yield %>
-      </div>
     </main>
     <%= render "shared/footer" %>
   </body>

--- a/app/views/layouts/vendor.html.erb
+++ b/app/views/layouts/vendor.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="autumn">
+<html data-theme="backstage">
   <head>
     <title>RestTime</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,11 +1,11 @@
 <%# 版頭圖片 %>
 <div class="content mb-10">
     <div class="hero min-h-screen" style="background-image: url('<%= asset_url('pages/banner.jpg') %>');">
-            <div class="hero-overlay bg-opacity-60"></div>
+            <div class="hero-overlay bg-opacity-60 bg-gray-400"></div>
             <div class="hero-content text-center text-neutral-content">
                 <div class="max-w-md">
-                <h2 class="m-5 text-5xl font-bold">ResTime</h2>
-                <p class="pb-5">
+                <h2 class="m-5 text-5xl text-white">ResTime</h2>
+                <p class="pb-5 text-white">
                 <%= t('homepage.slogan') %>
                 </p>
                 <div class="flex items-center justify-center">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,14 +1,14 @@
-<nav class="navbar bg-base-100 shadow-md p-1 fixed w-full top-0 z-20 mb-11">
+<nav class="navbar bg-accent p-1 fixed w-full top-0 z-20 mb-11">
   <div class="flex-1">
-    <h1 class="btn btn-ghost text-3xl text-orange-900"><%= link_to "RestTime", root_path %></h1>
-      <span class="btn btn-ghost hover:bg-accent text-slate-700"><%= link_to t('navbar.homepage'), index_path %></span>
-      <span class="btn btn-ghost hover:bg-accent text-sm text-slate-700"><%= link_to t('navbar.products'), products_path %></span>
-      <span class="btn btn-ghost hover:bg-accent text-slate-700"><%= link_to t('navbar.shops'), shops_path %></span>
+    <h1 class="btn btn-ghost text-3xl text-white"><%= link_to "RestTime", root_path %></h1>
+      <span class="btn btn-sm btn-ghost text-white"><%= link_to t('navbar.homepage'), index_path %></span>
+      <span class="btn btn-sm btn-ghost text-white"><%= link_to t('navbar.products'), products_path %></span>
+      <span class="btn btn-sm btn-ghost text-white"><%= link_to t('navbar.shops'), shops_path %></span>
   </div>
   <div class="flex items-center justify-center">
     <form action="<%= search_path %>" data-turbo="false">
-      <input type="search" name="q" class="input input-bordered">
-      <button class="btn btn-outline btn-accent">搜尋</button>
+      <input type="search" name="q" class="input input-bordered h-8">
+      <button class="btn btn-sm btn-primary">搜尋</button>
     </form>
   </div>
   <div class="flex-none">
@@ -18,10 +18,11 @@
           <details>
             <summary>
               <% if policy(:shop).index? %>
-                <div class="bg-red-500 text-white px-2 py-1 rounded-md text-sm inline-block">
+                <div class="bg-warning text-white px-2 py-1 rounded-md text-sm inline-block">
                   <%= t("user_roles.#{current_user.role}") %>
                 </div>
               <% end %>
+              <i class="fa-solid fa-user"></i>
               <%= current_user.email %>
             </summary>
   
@@ -38,8 +39,8 @@
           </details>
         </li>
       <% else %>
-        <li><%= link_to '註冊', new_user_registration_path %></li>
-        <li><%= link_to '登入', new_user_session_path %></li>
+        <li class="text-white"><%= link_to '註冊', new_user_registration_path %></li>
+        <li class="text-white"><%= link_to '登入', new_user_session_path %></li>
       <% end %>
     </ul>
 

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-accent", style="position: fixed; top: 0; z-index: 1000;">
+<nav class="navbar bg-success p-1 fixed w-full top-0 z-20 mb-11">
   <div class="navbar-start h-5">
     <div class="dropdown" data-controller="sidebar">
       <div tabindex="0" role="button" class="btn btn-ghost  btn-circle" data-action="click->sidebar#toggle">
@@ -22,10 +22,15 @@
     <ul class="flex menu menu-horizontal px-1">
       <li>
         <details>
-          <summary>
-            <i class="fa-solid fa-user"></i>
-            <li><%= current_user.email %></li>
-          </summary>
+            <summary>
+              <% if policy(:shop).index? %>
+                <div class="bg-warning text-white px-2 py-1 rounded-md text-sm inline-block">
+                  <%= t("user_roles.#{current_user.role}") %>
+                </div>
+              <% end %>
+              <i class="fa-solid fa-user"></i>
+              <%= current_user.email %>
+            </summary>
           <%# 下拉選單 %>
           <ul class="w-32 text-stone-600 ">
             <li><%= link_to t('navbar.logout'), destroy_user_session_path, data: { turbo_method: "delete" } %></li>
@@ -39,4 +44,4 @@
       </li>
     </ul>
   </div>
-</div>
+</nav>

--- a/app/views/vendor/_navbar.html.erb
+++ b/app/views/vendor/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar bg-success p-1 fixed w-full top-0 z-20 mb-11">
+<nav class="navbar bg-secondary p-1 fixed w-full top-0 z-20 mb-11">
   <div class="navbar-start h-5">
     <div class="dropdown" data-controller="sidebar">
       <div tabindex="0" role="button" class="btn btn-ghost  btn-circle" data-action="click->sidebar#toggle">
@@ -13,7 +13,7 @@
       </div>
     </div>
     <h1 class="btn btn-ghost text-2xl  text-white"><%= link_to "RestTime", root_path %></h1>
-    <div class="badge badge-secondary text-white text-s"><%=t('navbar.vendor_backstage')%></div>
+    <div class="badge badge-warning text-white text-s"><%=t('navbar.vendor_backstage')%></div>
     <span class="btn btn-ghost text-white"><%= link_to t('navbar.homepage_front'), index_path %></span>
 
   </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,11 +244,11 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).
-  # config.default_scope = :user
+  config.default_scope = :user
 
   # Set this configuration to false if you want /users/sign_out to sign out
   # only the current scope. By default, Devise signs out all scopes.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
   daisyui: {
     themes: [
       {
-        frontstage: {
+        mytheme: {
           "primary": "#4a7c59",
           "secondary": "#a98467",
           "accent": "#abc178",
@@ -21,20 +21,6 @@ module.exports = {
           "error": "#bc4b51",
         },
       },
-      {
-        backstage: {
-          "primary": "#6c584c",
-          "secondary": "#606C38",
-          "accent": "#a98467",
-          "neutral": "#DDA15E",
-          "base-100": "#f5f5f4",
-          "info": "#FEFAE0",
-          "success": "#a4ac86",
-          "warning": "#f4e285",
-          "error": "#bc4b51",
-        }
-      },
-      "autumn",
     ],
   },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,34 @@ module.exports = {
   ],
   plugins: [require("daisyui")],
   daisyui: {
-    themes: ["autumn"],
+    themes: [
+      {
+        frontstage: {
+          "primary": "#4a7c59",
+          "secondary": "#a98467",
+          "accent": "#abc178",
+          "neutral": "#dde5b6",
+          "base-100": "#f3f4f6",
+          "info": "#f0ead2",
+          "success": "#b5c99a",
+          "warning": "#f4a259",
+          "error": "#bc4b51",
+        },
+      },
+      {
+        backstage: {
+          "primary": "#6c584c",
+          "secondary": "#606C38",
+          "accent": "#a98467",
+          "neutral": "#DDA15E",
+          "base-100": "#f5f5f4",
+          "info": "#FEFAE0",
+          "success": "#a4ac86",
+          "warning": "#f4e285",
+          "error": "#bc4b51",
+        }
+      },
+      "autumn",
+    ],
   },
 };


### PR DESCRIPTION
- 調整daisyUI主色彩+套用在layout裡
- 調整商家登入後的路徑，跳轉編輯商品頁面

mytheme
<img width="277" alt="v4-frontstage" src="https://github.com/astrocamp/15th-RestTime/assets/147526390/11e831d0-d5cb-45a9-9066-b511991bd121">
```css
        mytheme: {
          "primary": "#4a7c59",
          "secondary": "#a98467",
          "accent": "#abc178",
          "neutral": "#dde5b6",
          "base-100": "#f3f4f6",
          "info": "#f0ead2",
          "success": "#b5c99a",
          "warning": "#f4a259",
          "error": "#bc4b51",
        },
```
前台頁面：
<img width="1436" alt="截圖 2024-01-11 下午3 02 19" src="https://github.com/astrocamp/15th-RestTime/assets/147526390/e8709640-9d8c-4edc-b639-b1d6ff5ba39a">

後台頁面：
<img width="1433" alt="截圖 2024-01-11 下午3 02 11" src="https://github.com/astrocamp/15th-RestTime/assets/147526390/b91116be-97bd-4b13-8d72-ff5165a14d06">

