### PR TITLE
修正無法進入付款頁面問題

### DIFF
--- a/app/controllers/api/v1/bookings_controller.rb
+++ b/app/controllers/api/v1/bookings_controller.rb
@@ -10,9 +10,8 @@ module Api
 
         booking_service = BookingService.new(@shop, product)
         available_slots = booking_service.display_available_slots(
-                            DateTime.parse(params[:booking_date],
-                                          '%Y/%m/%d %H:%M')
-                          )
+          DateTime.parse(params[:booking_date], '%Y/%m/%d %H:%M')
+        )
         render json: { available_slots: }
       end
 

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -45,7 +45,7 @@ class Shop < ApplicationRecord
   end
 
   def create_service_times
-    days = %w[monday tuesday wednesday thursday friday saturday sunday]
+    days = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday]
     days.each do |day|
       ServiceTime.create(day_of_week: day, off_day: true, shop: self)
     end

--- a/app/services/booking_service.rb
+++ b/app/services/booking_service.rb
@@ -18,9 +18,11 @@ class BookingService
 
     service_minutes = @product&.service_min&.minutes || 30.minutes
 
-    start_time = Time.new(date.year, date.month, date.day, open_time.hour, open_time.min, 0)
-    end_time = Time.new(date.year, date.month, date.day, close_time.hour, close_time.min,
-                        0) - service_minutes
+    start_time = Time.zone.local(date.year, date.month, date.day,
+                                 open_time.hour, open_time.min, 0)
+    end_time = Time.zone.local(date.year, date.month, date.day,
+                               close_time.hour, close_time.min, 0) - service_minutes
+
     while start_time < end_time
       slots << start_time
       start_time += 15.minutes # 每隔15分鐘


### PR DESCRIPTION
成立訂單前會檢查一次預約時間是否已被預定
判斷時使用Time.new導致時區為+0 
改使用Time.zone.local方式使用設定好的+8時區