### PR TITLE
後台營業時間設定排版及移除不需要的連結入口

### DIFF
--- a/app/models/service_time.rb
+++ b/app/models/service_time.rb
@@ -4,8 +4,6 @@ class ServiceTime < ApplicationRecord
   belongs_to :shop
   before_validation :validate_open_and_close_times, on: :update
 
-  default_scope { order(id: :desc) }
-
   private
 
   def validate_open_and_close_times

--- a/app/views/service_times/_input_time.html.erb
+++ b/app/views/service_times/_input_time.html.erb
@@ -5,5 +5,6 @@
                           controller: 'timepicker',
                           time: value&.then { |t| format_time_without_sec(t) }, 
                         },
-                        class: 'input input-bordered input-sm max-w-xs' %>
+                        class: 'input input-bordered input-sm max-w-xs',
+                        placeholder: t('service_times.choose_times') %>
 </div>

--- a/app/views/service_times/_service_times.html.erb
+++ b/app/views/service_times/_service_times.html.erb
@@ -3,7 +3,7 @@
   <div class="flex items-center ">
     <div>
       <%= service_time_field.label :day_of_week, 
-              t(service_time.day_of_week, scope: [:service_times]), 
+              t(service_time.day_of_week.downcase, scope: [:service_times]), 
               class: 'label content-center' %>
       <%= service_time_field.hidden_field :day_of_week %>
     </div>
@@ -16,8 +16,6 @@
     <div class="flex">
       <%= render 'input_time', column: :open_time, value: service_time.open_time, service_time_field: %>
       <%= render 'input_time', column: :close_time, value: service_time.close_time, service_time_field: %>
-      <%= render 'input_time', column: :lunch_start, value: service_time.lunch_start, service_time_field: %>
-      <%= render 'input_time', column: :lunch_end, value: service_time.lunch_end, service_time_field: %>  
     </div>    
   </section>
 </div>

--- a/app/views/service_times/edit.html.erb
+++ b/app/views/service_times/edit.html.erb
@@ -1,11 +1,14 @@
-<h1 class="text-xl"><%= t('service_times.title') %></h1>
-<section>
-  <%= form_with(model: @service_times, url: service_times_path, method: :patch, data:{ turbo: false }) do |f| %>
-    <% @service_times.each do |service_time| %>
-      <%= fields_for "service_times[]", service_time do |service_time_field| %>
-        <%= render 'service_times' , service_time: , service_time_field: %>
+
+<h2 class="text-2xl font-semibold text-primary mx-10 mt-6"><%= t('service_times.title') %></h2>
+<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+  <section class="form-control mx-10 my-6 p-6 bg-white rounded-xl shadow-xl">
+    <%= form_with(model: @service_times, url: service_times_path, method: :patch, data:{ turbo: false }) do |f| %>
+      <% @service_times.each do |service_time| %>
+        <%= fields_for "service_times[]", service_time do |service_time_field| %>
+          <%= render 'service_times' , service_time: , service_time_field: %>
+        <% end %>
       <% end %>
+      <%= f.submit t('service_times.submit'), class:'btn btn-accent mt-2'%>
     <% end %>
-    <%= f.submit t('service_times.submit'), class:'btn btn-sm my-4'%>
-  <% end %>
-</section>
+  </section>
+</div>

--- a/app/views/vendor/_sidebar.html.erb
+++ b/app/views/vendor/_sidebar.html.erb
@@ -2,9 +2,6 @@
   <div>
       <h2 class="menu-title"><%= t('vendor.my_backstage') %></h2>
       <li>
-        <%= link_to t('vendor.system_notification'), '#' %>
-      </li>
-      <li>
         <%= link_to  t('vendor.my_shop'), vendor_index_path%>
         <ul>
           <li><%= link_to t('service_times.title'), edit_service_times_path %></li>
@@ -18,8 +15,5 @@
       </li>
       <li>
         <%= link_to t('vendor.my_order'), my_vendor_orders_path %>
-      </li>
-      <li>
-        <%= link_to t('vendor.message'), '#' %>
       </li>
   </div>

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -90,6 +90,7 @@ tw:
     saturday: 星期六
     sunday: 星期日
     submit: 更新營業時間
+    choose_times: 選擇時間
     message:
       success: 營業時間更新成功
       Close time can't be blank if open time is set: 設定開始時間必須填寫結束時間


### PR DESCRIPTION
- 移除未使用連結
  - 系統通知
  - 客戶訊息
<img width="302" alt="image" src="https://github.com/astrocamp/15th-RestTime/assets/8993798/fb13e50c-44a2-4c1f-8f7a-cb38e3bdfc86">

- 調整營業時間設定排版與其他畫面風格一致
<img width="838" alt="image" src="https://github.com/astrocamp/15th-RestTime/assets/8993798/69583c00-4572-4f7f-90c2-bca4455cc916">
 
 - 排序調整
 - 增加未填寫時間的placeholder